### PR TITLE
fix: ensuring 2factor is enabled for all users as an option

### DIFF
--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -50,6 +50,20 @@ class Two_Factor_Core {
 	const USER_FAILED_LOGIN_ATTEMPTS_KEY = '_two_factor_failed_login_attempts';
 
 	/**
+	 * Option key for requiring two-factor (email by default) for all users.
+	 *
+	 * @type string
+	 */
+	const FORCE_ALL_USERS_OPTION_KEY = 'two_factor_force_all_users';
+
+	/**
+	 * Default provider when two-factor is applied site-wide for a user.
+	 *
+	 * @type string
+	 */
+	const FORCE_ALL_USERS_DEFAULT_PROVIDER = 'Two_Factor_Email';
+
+	/**
 	 * The user meta key to store whether or not the password was reset.
 	 *
 	 * @var string
@@ -189,7 +203,10 @@ class Two_Factor_Core {
 			self::USER_PASSWORD_WAS_RESET_KEY,
 		);
 
-		$option_keys = array();
+		$option_keys = array(
+			self::FORCE_ALL_USERS_OPTION_KEY,
+			'two_factor_enabled_providers',
+		);
 
 		$providers = self::get_default_providers();
 
@@ -782,6 +799,17 @@ class Two_Factor_Core {
 		return null;
 	}
 
+	public static function maybe_log( $message ) {
+
+		$WP_DEBUG = defined('WP_DEBUG') ? WP_DEBUG : false;
+		$WP_DEBUG_LOG = defined('WP_DEBUG_LOG') ? WP_DEBUG_LOG : false;
+		if(!$WP_DEBUG || !$WP_DEBUG_LOG) {
+			return;
+		}
+
+		error_log( $message );
+	}
+
 	/**
 	 * Gets the Two-Factor Auth provider for the specified|current user.
 	 *
@@ -865,17 +893,23 @@ class Two_Factor_Core {
 			$current_origin = ! empty( $_SERVER['HTTP_REFERER'] ) ? sanitize_text_field( $_SERVER['HTTP_REFERER'] ) : null;
 		}
 
-		// get frontend url
-		$faustwp_settings = get_option('faustwp_settings');
+		if ( ! self::is_user_using_two_factor( $user->ID ) ) {
+			self::maybe_log( 'Two-factor is not enabled for user: ' . $user->ID . ' because it is not enabled' );
+			return;
+		}
 
-		$frontend_uri = ($faustwp_settings['frontend_uri']);
-	
-		// this is returning "https:\/\/localhost:3000"
-		// we need it in the format https://localhost:3000
-		$frontend_uri = str_replace('\\', '', $frontend_uri);
-		$frontend_uri = str_replace('"', '', $frontend_uri);
-	
-		if ( ! self::is_user_using_two_factor( $user->ID ) || $current_origin === $frontend_uri ) {
+		// Skip 2FA when logging in from the FaustWP headless frontend (if configured).
+		$faustwp_settings = get_option( 'faustwp_settings' );
+		$frontend_uri     = '';
+
+		if ( is_array( $faustwp_settings ) && ! empty( $faustwp_settings['frontend_uri'] ) ) {
+			// Stored value may include escaped slashes/quotes, e.g. "https:\/\/localhost:3000".
+			$frontend_uri = (string) $faustwp_settings['frontend_uri'];
+			$frontend_uri = str_replace( array( '\\', '"' ), '', $frontend_uri );
+		}
+
+		if ( $frontend_uri && $current_origin === $frontend_uri ) {
+			self::maybe_log( 'Two-factor is not enabled for user: ' . $user->ID . ' because it is from the FaustWP headless frontend' );
 			return;
 		}
 	
@@ -2356,6 +2390,95 @@ class Two_Factor_Core {
 	}
 
 	/**
+	 * Whether two-factor is required for every user (email by default).
+	 *
+	 * @since 0.16.1
+	 *
+	 * @return bool
+	 */
+	public static function is_force_all_users_enabled() {
+		return (bool) get_option( self::FORCE_ALL_USERS_OPTION_KEY, false );
+	}
+
+	/**
+	 * Enable email two-factor for a user who has no methods configured yet.
+	 *
+	 * @since 0.16.1
+	 *
+	 * @param int $user_id User ID.
+	 * @return bool True when the user has email two-factor after this call.
+	 */
+	public static function enable_email_for_user( $user_id ) {
+		$user = self::fetch_user( $user_id );
+		if ( ! $user ) {
+			return false;
+		}
+
+		$providers = self::get_supported_providers_for_user( $user );
+		if ( ! isset( $providers[ self::FORCE_ALL_USERS_DEFAULT_PROVIDER ] ) ) {
+			return false;
+		}
+
+		$enabled_providers = get_user_meta( $user_id, self::ENABLED_PROVIDERS_USER_META_KEY, true );
+		if ( ! empty( $enabled_providers ) ) {
+			return true;
+		}
+
+		update_user_meta( $user_id, self::ENABLED_PROVIDERS_USER_META_KEY, array( self::FORCE_ALL_USERS_DEFAULT_PROVIDER ) );
+		update_user_meta( $user_id, self::PROVIDER_USER_META_KEY, self::FORCE_ALL_USERS_DEFAULT_PROVIDER );
+
+		return true;
+	}
+
+	/**
+	 * Apply site-wide two-factor to any user without a configured method.
+	 *
+	 * @since 0.16.1
+	 *
+	 * @return int Number of users updated.
+	 */
+	public static function apply_force_all_users_to_all_accounts() {
+		if ( ! self::is_force_all_users_enabled() ) {
+			return 0;
+		}
+
+		$user_ids = get_users(
+			array(
+				'fields' => 'ID',
+			)
+		);
+
+		$updated = 0;
+
+		foreach ( $user_ids as $user_id ) {
+			$user_id      = (int) $user_id;
+			$was_enabled  = get_user_meta( $user_id, self::ENABLED_PROVIDERS_USER_META_KEY, true );
+
+			if ( self::enable_email_for_user( $user_id ) && empty( $was_enabled ) ) {
+				++$updated;
+			}
+		}
+
+		return $updated;
+	}
+
+	/**
+	 * Ensure a user has email two-factor when site-wide enforcement is enabled.
+	 *
+	 * @since 0.16.1
+	 *
+	 * @param int $user_id User ID.
+	 * @return void
+	 */
+	public static function ensure_forced_email_for_user( $user_id ) {
+		if ( ! self::is_force_all_users_enabled() ) {
+			return;
+		}
+
+		self::enable_email_for_user( $user_id );
+	}
+
+	/**
 	 * Enable a provider for a user.
 	 *
 	 * The caller is responsible for checking the user has permission to do this.
@@ -2485,10 +2608,14 @@ class Two_Factor_Core {
 				delete_user_meta( $user_id, self::PROVIDER_USER_META_KEY );
 			}
 
+			self::ensure_forced_email_for_user( $user_id );
+
+			$enabled_provider_keys = self::get_enabled_providers_for_user( $user_id );
+
 			// Have we changed the two-factor settings for the current user? Alter their session metadata.
 			if ( get_current_user_id() === $user_id ) {
 
-				if ( $enabled_providers && ! $existing_providers && ! self::is_current_user_session_two_factor() ) {
+				if ( $enabled_provider_keys && ! $existing_providers && ! self::is_current_user_session_two_factor() ) {
 					// We've enabled two-factor from a non-two-factor session, set the key but not the provider, as no provider has been used yet.
 					self::update_current_user_session(
 						array(
@@ -2496,7 +2623,7 @@ class Two_Factor_Core {
 							'two-factor-login'    => time(),
 						)
 					);
-				} elseif ( $existing_providers && ! $enabled_providers ) {
+				} elseif ( $existing_providers && ! $enabled_provider_keys ) {
 					// We've disabled two-factor, remove session metadata.
 					self::update_current_user_session(
 						array(
@@ -2510,9 +2637,9 @@ class Two_Factor_Core {
 			// Destroy other sessions if setup 2FA for the first time, or deactivated a provider.
 			if (
 				// No providers, enabling one (or more).
-				( ! $existing_providers && $enabled_providers ) ||
+				( ! $existing_providers && $enabled_provider_keys ) ||
 				// Has providers, and is disabling one (or more), but remaining with 2FA.
-				( $existing_providers && $enabled_providers && array_diff( $existing_providers, array_keys( $enabled_providers ) ) )
+				( $existing_providers && $enabled_provider_keys && array_diff( $existing_providers, $enabled_provider_keys ) )
 			) {
 				if ( get_current_user_id() === $user_id ) {
 					// Keep the current session, destroy others sessions for this user.

--- a/class-two-factor-core.php
+++ b/class-two-factor-core.php
@@ -64,6 +64,27 @@ class Two_Factor_Core {
 	const FORCE_ALL_USERS_DEFAULT_PROVIDER = 'Two_Factor_Email';
 
 	/**
+	 * Cron hook for backfilling email two-factor onto existing users.
+	 *
+	 * @type string
+	 */
+	const FORCE_ALL_USERS_CRON_HOOK = 'two_factor_apply_force_all_users_batch';
+
+	/**
+	 * Option storing the user-query offset for the force-all backfill.
+	 *
+	 * @type string
+	 */
+	const FORCE_ALL_USERS_BATCH_OFFSET_OPTION = 'two_factor_force_all_users_batch_offset';
+
+	/**
+	 * Number of users processed per backfill batch.
+	 *
+	 * @type int
+	 */
+	const FORCE_ALL_USERS_BATCH_SIZE = 100;
+
+	/**
 	 * The user meta key to store whether or not the password was reset.
 	 *
 	 * @var string
@@ -193,6 +214,8 @@ class Two_Factor_Core {
 	 * @return void
 	 */
 	public static function uninstall() {
+		self::cancel_force_all_users_backfill();
+
 		// Keep this updated as user meta keys are added or removed.
 		$user_meta_keys = array(
 			self::PROVIDER_USER_META_KEY,
@@ -205,6 +228,7 @@ class Two_Factor_Core {
 
 		$option_keys = array(
 			self::FORCE_ALL_USERS_OPTION_KEY,
+			self::FORCE_ALL_USERS_BATCH_OFFSET_OPTION,
 			'two_factor_enabled_providers',
 		);
 
@@ -799,17 +823,6 @@ class Two_Factor_Core {
 		return null;
 	}
 
-	public static function maybe_log( $message ) {
-
-		$WP_DEBUG = defined('WP_DEBUG') ? WP_DEBUG : false;
-		$WP_DEBUG_LOG = defined('WP_DEBUG_LOG') ? WP_DEBUG_LOG : false;
-		if(!$WP_DEBUG || !$WP_DEBUG_LOG) {
-			return;
-		}
-
-		error_log( $message );
-	}
-
 	/**
 	 * Gets the Two-Factor Auth provider for the specified|current user.
 	 *
@@ -894,7 +907,6 @@ class Two_Factor_Core {
 		}
 
 		if ( ! self::is_user_using_two_factor( $user->ID ) ) {
-			self::maybe_log( 'Two-factor is not enabled for user: ' . $user->ID . ' because it is not enabled' );
 			return;
 		}
 
@@ -909,7 +921,6 @@ class Two_Factor_Core {
 		}
 
 		if ( $frontend_uri && $current_origin === $frontend_uri ) {
-			self::maybe_log( 'Two-factor is not enabled for user: ' . $user->ID . ' because it is from the FaustWP headless frontend' );
 			return;
 		}
 	
@@ -2409,6 +2420,11 @@ class Two_Factor_Core {
 	 * @return bool True when the user has email two-factor after this call.
 	 */
 	public static function enable_email_for_user( $user_id ) {
+		$enabled_providers = get_user_meta( $user_id, self::ENABLED_PROVIDERS_USER_META_KEY, true );
+		if ( ! empty( $enabled_providers ) ) {
+			return true;
+		}
+
 		$user = self::fetch_user( $user_id );
 		if ( ! $user ) {
 			return false;
@@ -2419,9 +2435,21 @@ class Two_Factor_Core {
 			return false;
 		}
 
+		return self::enable_email_for_user_if_unconfigured( $user_id );
+	}
+
+	/**
+	 * Enable email two-factor when the user has no methods configured (meta only).
+	 *
+	 * @since 0.16.1
+	 *
+	 * @param int $user_id User ID.
+	 * @return bool True when email was enabled, false if already configured or update failed.
+	 */
+	private static function enable_email_for_user_if_unconfigured( $user_id ) {
 		$enabled_providers = get_user_meta( $user_id, self::ENABLED_PROVIDERS_USER_META_KEY, true );
 		if ( ! empty( $enabled_providers ) ) {
-			return true;
+			return false;
 		}
 
 		update_user_meta( $user_id, self::ENABLED_PROVIDERS_USER_META_KEY, array( self::FORCE_ALL_USERS_DEFAULT_PROVIDER ) );
@@ -2431,35 +2459,76 @@ class Two_Factor_Core {
 	}
 
 	/**
-	 * Apply site-wide two-factor to any user without a configured method.
+	 * Whether a background backfill is running for site-wide enforcement.
 	 *
 	 * @since 0.16.1
 	 *
-	 * @return int Number of users updated.
+	 * @return bool
 	 */
-	public static function apply_force_all_users_to_all_accounts() {
+	public static function is_force_all_users_backfill_running() {
+		return (bool) wp_next_scheduled( self::FORCE_ALL_USERS_CRON_HOOK );
+	}
+
+	/**
+	 * Schedule batched backfill of email two-factor for existing users.
+	 *
+	 * @since 0.16.1
+	 *
+	 * @return void
+	 */
+	public static function schedule_force_all_users_backfill() {
+		self::cancel_force_all_users_backfill();
+		update_option( self::FORCE_ALL_USERS_BATCH_OFFSET_OPTION, 0 );
+		wp_schedule_single_event( time(), self::FORCE_ALL_USERS_CRON_HOOK );
+	}
+
+	/**
+	 * Cancel any in-progress site-wide backfill.
+	 *
+	 * @since 0.16.1
+	 *
+	 * @return void
+	 */
+	public static function cancel_force_all_users_backfill() {
+		wp_clear_scheduled_hook( self::FORCE_ALL_USERS_CRON_HOOK );
+		delete_option( self::FORCE_ALL_USERS_BATCH_OFFSET_OPTION );
+	}
+
+	/**
+	 * Process one batch of the site-wide email two-factor backfill.
+	 *
+	 * @since 0.16.1
+	 *
+	 * @return void
+	 */
+	public static function process_force_all_users_batch() {
 		if ( ! self::is_force_all_users_enabled() ) {
-			return 0;
+			self::cancel_force_all_users_backfill();
+			return;
 		}
 
+		$offset   = (int) get_option( self::FORCE_ALL_USERS_BATCH_OFFSET_OPTION, 0 );
 		$user_ids = get_users(
 			array(
-				'fields' => 'ID',
+				'fields'  => 'ID',
+				'number'  => self::FORCE_ALL_USERS_BATCH_SIZE,
+				'offset'  => $offset,
+				'orderby' => 'ID',
+				'order'   => 'ASC',
 			)
 		);
 
-		$updated = 0;
-
-		foreach ( $user_ids as $user_id ) {
-			$user_id      = (int) $user_id;
-			$was_enabled  = get_user_meta( $user_id, self::ENABLED_PROVIDERS_USER_META_KEY, true );
-
-			if ( self::enable_email_for_user( $user_id ) && empty( $was_enabled ) ) {
-				++$updated;
-			}
+		if ( empty( $user_ids ) ) {
+			self::cancel_force_all_users_backfill();
+			return;
 		}
 
-		return $updated;
+		foreach ( $user_ids as $user_id ) {
+			self::enable_email_for_user_if_unconfigured( (int) $user_id );
+		}
+
+		update_option( self::FORCE_ALL_USERS_BATCH_OFFSET_OPTION, $offset + count( $user_ids ) );
+		wp_schedule_single_event( time() + 1, self::FORCE_ALL_USERS_CRON_HOOK );
 	}
 
 	/**

--- a/settings/class-two-factor-settings.php
+++ b/settings/class-two-factor-settings.php
@@ -28,11 +28,13 @@ class Two_Factor_Settings {
 			return;
 		}
 
-		$users_updated = 0;
+		$backfill_scheduled = false;
 
 		// Handle save.
 		if ( isset( $_POST['two_factor_settings_submit'] ) ) {
 			check_admin_referer( 'two_factor_save_settings', 'two_factor_settings_nonce' );
+
+			$was_force_all_users = class_exists( 'Two_Factor_Core' ) && Two_Factor_Core::is_force_all_users_enabled();
 
 			$posted = isset( $_POST['two_factor_enabled_providers'] ) && is_array( $_POST['two_factor_enabled_providers'] ) ? wp_unslash( $_POST['two_factor_enabled_providers'] ) : array();
 
@@ -50,26 +52,16 @@ class Two_Factor_Settings {
 			update_option( 'two_factor_enabled_providers', array_values( array_unique( $enabled ) ) );
 			update_option( Two_Factor_Core::FORCE_ALL_USERS_OPTION_KEY, $force_all_users );
 
-			if ( $force_all_users ) {
-				$users_updated = Two_Factor_Core::apply_force_all_users_to_all_accounts();
+			if ( $force_all_users && ! $was_force_all_users ) {
+				Two_Factor_Core::schedule_force_all_users_backfill();
+				$backfill_scheduled = true;
+			} elseif ( ! $force_all_users && $was_force_all_users ) {
+				Two_Factor_Core::cancel_force_all_users_backfill();
 			}
 
 			echo '<div class="updated"><p>' . esc_html__( 'Settings saved.', 'two-factor' ) . '</p></div>';
-			if ( $force_all_users && $users_updated > 0 ) {
-				echo '<div class="updated"><p>';
-				printf(
-					/* translators: %d: number of users */
-					esc_html(
-						_n(
-							'Email two-factor authentication was enabled for %d user who did not have a method configured.',
-							'Email two-factor authentication was enabled for %d users who did not have a method configured.',
-							$users_updated,
-							'two-factor'
-						)
-					),
-					(int) $users_updated
-				);
-				echo '</p></div>';
+			if ( $backfill_scheduled ) {
+				echo '<div class="updated"><p>' . esc_html__( 'Email two-factor is being enabled for existing users in the background. New users will be enrolled automatically.', 'two-factor' ) . '</p></div>';
 			}
 		}
 
@@ -119,6 +111,10 @@ class Two_Factor_Settings {
 
 		echo '</tbody></table>';
 		echo '</fieldset>';
+
+		if ( class_exists( 'Two_Factor_Core' ) && Two_Factor_Core::is_force_all_users_backfill_running() ) {
+			echo '<div class="notice notice-info"><p>' . esc_html__( 'Enabling email two-factor for existing users is in progress.', 'two-factor' ) . '</p></div>';
+		}
 
 		echo '<h2>' . esc_html__( 'Site-wide Enforcement', 'two-factor' ) . '</h2>';
 		echo '<table class="form-table"><tbody>';

--- a/settings/class-two-factor-settings.php
+++ b/settings/class-two-factor-settings.php
@@ -28,6 +28,8 @@ class Two_Factor_Settings {
 			return;
 		}
 
+		$users_updated = 0;
+
 		// Handle save.
 		if ( isset( $_POST['two_factor_settings_submit'] ) ) {
 			check_admin_referer( 'two_factor_save_settings', 'two_factor_settings_nonce' );
@@ -39,9 +41,36 @@ class Two_Factor_Settings {
 			// Remove empty values.
 			$enabled = array_values( array_filter( $posted, 'strlen' ) );
 
+			$force_all_users = ! empty( $_POST['two_factor_force_all_users'] );
+
+			if ( $force_all_users && ! in_array( Two_Factor_Core::FORCE_ALL_USERS_DEFAULT_PROVIDER, $enabled, true ) ) {
+				$enabled[] = Two_Factor_Core::FORCE_ALL_USERS_DEFAULT_PROVIDER;
+			}
+
 			update_option( 'two_factor_enabled_providers', array_values( array_unique( $enabled ) ) );
+			update_option( Two_Factor_Core::FORCE_ALL_USERS_OPTION_KEY, $force_all_users );
+
+			if ( $force_all_users ) {
+				$users_updated = Two_Factor_Core::apply_force_all_users_to_all_accounts();
+			}
 
 			echo '<div class="updated"><p>' . esc_html__( 'Settings saved.', 'two-factor' ) . '</p></div>';
+			if ( $force_all_users && $users_updated > 0 ) {
+				echo '<div class="updated"><p>';
+				printf(
+					/* translators: %d: number of users */
+					esc_html(
+						_n(
+							'Email two-factor authentication was enabled for %d user who did not have a method configured.',
+							'Email two-factor authentication was enabled for %d users who did not have a method configured.',
+							$users_updated,
+							'two-factor'
+						)
+					),
+					(int) $users_updated
+				);
+				echo '</p></div>';
+			}
 		}
 
 		// Build provider list for display using public core API.
@@ -56,13 +85,15 @@ class Two_Factor_Settings {
 		// Default to all providers enabled when the option has never been saved.
 		$all_provider_keys = array_keys( $provider_instances );
 		$saved_enabled     = get_option( 'two_factor_enabled_providers', $all_provider_keys );
+		$force_all_users   = class_exists( 'Two_Factor_Core' ) && Two_Factor_Core::is_force_all_users_enabled();
 
 		echo '<div class="wrap two-factor-settings">';
 		echo '<h1>' . esc_html__( 'Two-Factor Settings', 'two-factor' ) . '</h1>';
-		echo '<h2>' . esc_html__( 'Enabled Providers', 'two-factor' ) . '</h2>';
-		echo '<p class="description">' . esc_html__( 'Choose which Two-Factor providers are available on this site. All providers are enabled by default.', 'two-factor' ) . '</p>';
 		echo '<form method="post" action="">';
 		wp_nonce_field( 'two_factor_save_settings', 'two_factor_settings_nonce' );
+
+		echo '<h2>' . esc_html__( 'Enabled Providers', 'two-factor' ) . '</h2>';
+		echo '<p class="description">' . esc_html__( 'Choose which Two-Factor providers are available on this site. All providers are enabled by default.', 'two-factor' ) . '</p>';
 
 		echo '<fieldset class="two-factor-providers"><legend class="screen-reader-text">' . esc_html__( 'Providers', 'two-factor' ) . '</legend>';
 		echo '<table class="form-table"><tbody>';
@@ -88,6 +119,22 @@ class Two_Factor_Settings {
 
 		echo '</tbody></table>';
 		echo '</fieldset>';
+
+		echo '<h2>' . esc_html__( 'Site-wide Enforcement', 'two-factor' ) . '</h2>';
+		echo '<table class="form-table"><tbody>';
+		echo '<tr>';
+		echo '<th scope="row">' . esc_html__( 'Require for all users', 'two-factor' ) . '</th>';
+		echo '<td>';
+		echo '<label for="two_factor_force_all_users">';
+		echo '<input type="checkbox" name="two_factor_force_all_users" id="two_factor_force_all_users" value="1" ' . checked( $force_all_users, true, false ) . ' /> ';
+		echo esc_html__( 'Enable two-factor authentication for all users', 'two-factor' );
+		echo '</label>';
+		echo '<p class="description">';
+		echo esc_html__( 'Users without a configured method will use email codes by default. They can add other methods, such as an authenticator app or backup codes, from their profile.', 'two-factor' );
+		echo '</p>';
+		echo '</td>';
+		echo '</tr>';
+		echo '</tbody></table>';
 
 		submit_button( __( 'Save Settings', 'two-factor' ), 'primary', 'two_factor_settings_submit' );
 		echo '</form>';

--- a/two-factor.php
+++ b/two-factor.php
@@ -77,6 +77,9 @@ function two_factor_register_admin_hooks() {
 	/* Enforcement filters: restrict providers based on saved enabled-providers option. */
 	add_filter( 'two_factor_providers', 'two_factor_filter_enabled_providers' );
 	add_filter( 'two_factor_enabled_providers_for_user', 'two_factor_filter_enabled_providers_for_user', 10, 2 );
+	add_filter( 'two_factor_enabled_providers_for_user', 'two_factor_maybe_force_email_for_user', 20, 2 );
+
+	add_action( 'user_register', 'two_factor_enable_email_for_new_user' );
 }
 
 add_action( 'init', 'two_factor_register_admin_hooks' );
@@ -187,4 +190,47 @@ function two_factor_filter_enabled_providers_for_user( $enabled, $user_id ) {
 	}
 
 	return array_values( array_intersect( (array) $enabled, $site_enabled ) );
+}
+
+/**
+ * When site-wide enforcement is on, users without a method use email by default.
+ *
+ * @since 0.16.1
+ *
+ * @param array $enabled Enabled provider classnames for the user.
+ * @param int   $user_id User ID.
+ * @return array
+ */
+function two_factor_maybe_force_email_for_user( $enabled, $user_id ) {
+	if ( ! class_exists( 'Two_Factor_Core' ) || ! Two_Factor_Core::is_force_all_users_enabled() ) {
+		return $enabled;
+	}
+
+	if ( ! empty( $enabled ) ) {
+		return $enabled;
+	}
+
+	$site_enabled = two_factor_get_enabled_providers_option();
+
+	if ( null !== $site_enabled && ! in_array( Two_Factor_Core::FORCE_ALL_USERS_DEFAULT_PROVIDER, $site_enabled, true ) ) {
+		return $enabled;
+	}
+
+	return array( Two_Factor_Core::FORCE_ALL_USERS_DEFAULT_PROVIDER );
+}
+
+/**
+ * Enable email two-factor for newly registered users when site-wide enforcement is on.
+ *
+ * @since 0.16.1
+ *
+ * @param int $user_id User ID.
+ * @return void
+ */
+function two_factor_enable_email_for_new_user( $user_id ) {
+	if ( ! class_exists( 'Two_Factor_Core' ) || ! Two_Factor_Core::is_force_all_users_enabled() ) {
+		return;
+	}
+
+	Two_Factor_Core::enable_email_for_user( $user_id );
 }

--- a/two-factor.php
+++ b/two-factor.php
@@ -84,6 +84,8 @@ function two_factor_register_admin_hooks() {
 
 add_action( 'init', 'two_factor_register_admin_hooks' );
 
+add_action( Two_Factor_Core::FORCE_ALL_USERS_CRON_HOOK, array( 'Two_Factor_Core', 'process_force_all_users_batch' ) );
+
 /**
  * Add the Two Factor settings page under Settings.
  *


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new site-wide enforcement path that automatically enables email-based 2FA for users, including a cron-driven backfill over all accounts; mistakes here could unexpectedly lock users out or generate unexpected email-based login flows.
> 
> **Overview**
> Adds an optional **site-wide “require 2FA for all users”** setting that forces `Two_Factor_Email` as the default method for users who have no 2FA configured, including automatic enrollment for new registrations.
> 
> Implements a cron-backed batch backfill to enable email 2FA for existing users when enforcement is turned on, exposes progress messaging in the settings UI, and ensures forced email is re-applied after profile updates; uninstall now also clears the new enforcement options/cron state.
> 
> Tightens `wp_login` handling by skipping 2FA only for the configured FaustWP frontend origin and returning early for non-2FA users, avoiding reliance on possibly-missing Faust settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31ddaa140548188b1c10248d2f9494ecab517d5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->